### PR TITLE
201912300006

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2187,8 +2187,11 @@ static int isFileReadable(const char *path, u32 *sz)
 		ret = PTR_ERR(fp);
 	else {
 		oldfs = get_fs();
-		set_fs(get_ds());
-
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+			set_fs(KERNEL_DS);
+		#else
+			set_fs(get_ds());
+		#endif		
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
 
@@ -2225,7 +2228,11 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+				set_fs(KERNEL_DS);
+			#else
+				set_fs(get_ds());
+			#endif		
 			ret = readFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);
@@ -2260,7 +2267,11 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
+				set_fs(KERNEL_DS);
+			#else
+				set_fs(get_ds());
+			#endif		
 			ret = writeFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);


### PR DESCRIPTION
From Kernel 5.1 get_ds is removed and replaced by KERNEL_DS. Path replacing the occurrences of get_ds with KERNEL_DS

Ref. https://github.com/torvalds/linux/commit/736706bee3298208343a76096370e4f6a5c55915