### PR TITLE
IEEE80211_MAX_AMPDU_BUF compile warning fixed

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1028,8 +1028,9 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
-#define IEEE80211_MAX_AMPDU_BUF 0x40
-
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
+	#define IEEE80211_MAX_AMPDU_BUF 0x40
+#endif
 
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0


### PR DESCRIPTION
IEEE80211_MAX_AMPDU_BUF is bumped in 4.19-rc1 - avoid redefine warning 

In file included from /home/sardnailap/bin_github/TP-LINK_Archer_T4U_v3/include/drv_types.h:30,
                 from /home/sardnailap/bin_github/TP-LINK_Archer_T4U_v3/core/rtw_xmit.c:17:
/home/sardnailap/bin_github/TP-LINK_Archer_T4U_v3/include/wifi.h:1031: warning: "IEEE80211_MAX_AMPDU_BUF" redefined
 1031 | #define IEEE80211_MAX_AMPDU_BUF 0x40

Ref: https://github.com/lwfinger/rtl8188eu/commit/b8e342b103a00854258ae51111197d356dda44b9