### PR TITLE
Fix of build regression for linux kernel version <5

### DIFF
--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -657,7 +657,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
 	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+#else
+	if (!access_ok(VERIFY_READ,priv_cmd.buf, priv_cmd.total_len)) {
+#endif
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;


### PR DESCRIPTION
The "type" parameter of "access_ok" has been removed in linux kernel v5.0.0, but is mandatory for older versions.

Fixes issue #9 